### PR TITLE
Get live progress from the Juicebox contract

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,16 +24,21 @@ const BrowserOnlyAxios = () => {
 
         // console.log(JBContractInstance);
 
-        axios.get("https://api.etherscan.io/api?module=account&action=balance&address=0xce4a1E86a5c47CD677338f53DA22A91d85cab2c9&tag=latest&apikey=TJ95PY19ASCIBJQWX4T77V9MTHG7P57CKS")
+        axios.get("https://api.etherscan.io/api?module=proxy&action=eth_call&to=0xd569d3cce55b71a8a3f3c418c329a66e5f714431&data=0x9cc7f70800000000000000000000000000000000000000000000000000000000000000c7&tag=latest&apikey=TJ95PY19ASCIBJQWX4T77V9MTHG7P57CKS")
           .then(etherscanRawResponse => {
             console.log(etherscanRawResponse.data);
-            var ethStr = etherscanRawResponse.data.result;
 
-            ethStr = ethStr.substring(0, ethStr.length - 18) + "." + ethStr.substring(ethStr.length - 18, ethStr.length);
-            console.log(ethStr);
+            // Initial value set in case network call fails.
+            let ethVal = 62.43;
 
-            // const ethVal = parseFloat(ethStr);
-            const ethVal = 62.43;
+            // Convert hex to int.
+            const wei = parseInt(etherscanRawResponse.data.result, 16);
+            let eth = wei / 1000000000000000000;
+             //  Round to 2 decimal places.
+            eth = Math.round(eth * 100) / 100;
+            if (eth) {
+              ethVal = eth;
+            }
 
             axios.get("https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=USD")
               .then(rawResponse => {


### PR DESCRIPTION
Uses the Etherscan Proxy API to call the Juicebox for `balanceOf(199)`.

Reference: 
- https://docs.etherscan.io/api-endpoints/geth-parity-proxy#eth_call
- https://docs.juicebox.money/resources/contract-addresses#juicebox-protocol-v1
- https://etherscan.io/address/0xd569D3CCE55b71a8a3f3C418c329A66e5f714431#readContract