### PR TITLE
fix typo in total ETH raised

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -114,7 +114,7 @@ async function fetchAndUpdateProgress() {
     ',',
   );
   const ethGoal = (TARGET_USD / usdToEth).toFixed(2);
-  document.getElementById('endRaise').textContent = '2508.78 ETH ' + String.fromCodePoint(0x23E9) + ' $' + usdReadable;
+  document.getElementById('endRaise').textContent = '2503.78 ETH ' + String.fromCodePoint(0x23E9) + ' $' + usdReadable;
 }
 
 const BrowserOnlyAxios = () => {
@@ -151,7 +151,7 @@ export default function Home() {
                 <Translate>Our token launch raised...</Translate>
               </h2>
               <h1 className="BigP" id="endRaise">
-                2508.78 ETH &#x23E9; ...
+                2503.78 ETH &#x23E9; ...
               </h1>
               <p className="BigP" id="thankYou">
                 <Translate>


### PR DESCRIPTION
Hard coded ETH number in the web copy differed from the `RAISED_ETH` variable used to calculate the USD value.