### PR TITLE
Update token page and treasury total

### DIFF
--- a/docs/token.md
+++ b/docs/token.md
@@ -18,34 +18,28 @@ sidebar_label: $MOONEY token
 sidebar_position: 2
 ---
 
-The $MOONEY token launched on **Friday, December 17, 2021** on Juicebox. The funding period will last for one lunar cycle and will end on \*\*Sunday, January 16, 2022 at 3:18 PM EST.
+The $MOONEY token launched on **Friday, December 17, 2021** on Juicebox. The funding period lasted for one lunar cycle and ended on **Sunday, January 16, 2022 at 3:18 PM EST**.
 
-[Buy $MOONEY on Juicebox](https://juicebox.money/#/p/moondao)
+## Contract address
 
-## How to buy $MOONEY
+[0x20d4DB1946859E2Adb0e5ACC2eac58047aD41395](https://etherscan.io/address/0x20d4DB1946859E2Adb0e5ACC2eac58047aD41395)
 
-The following videos in English and Spanish explain how to buy $MOONEY with ETH on Juicebox.
+## How to get $MOONEY
 
-### English
+The best way to get $MOONEY is by working with us to help build the DAO and carry out our mission. For more information, see our [Contribute](/docs/contribute) page.
 
-<div class='video-container'>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/SWoyakGpMvc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
+Obviously you can buy $MOONEY on decentralized exchanges, but we would much rather have you work for us :-)
 
-### Spanish
+## Distribution & tokenomics
 
-<div class='video-container'>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/xa0CN5OWjow" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>
+1. Our token has a fixed supply. Now that our initial token raise is over, we will never increase the supply of the tokens.
 
-## Distribution & Tokenomics
+2. Our token is used for governance decisions. We will have proportional governance up to a community decided limit. The limit is needed so that if one person buys more than 51% of the tokens they cannot centrally control the DAO’s decisions. To begin, we will use a 4% limit of the total coin supply, however anyone is welcome to purchase more than 4% if they would like to contribute more.
 
-1. Our token will have a fixed supply. Once our initial token raise is over, we will never increase the supply of the tokens.
+3. The funds raised from this token will pay the workers needed to complete the rest of the roadmap (NFT designers, website developers, solidity developers, marketing, legal consulting, etc.).
 
-2. Our token will be used for governance decisions. We will have proportional governance up to a community decided limit. The limit is needed so that if one person buys more than 51% of the tokens they cannot centrally control the DAO’s decisions. To begin, we will use a 4% limit of the total coin supply, however anyone is welcome to purchase more than 4% if they would like to contribute more.
+4. The token raise was conducted on Juicebox, and every contribution created governance tokens at a fixed rate. Contributors received 50% of those tokens in their wallets, and the remaining 50% stay with the DAO in order to fund the work required to make this DAO function. These tokens form part of the shared treasury that token holders can vote on with their tokens.
 
-3. The money raised from this token will fund the workers (NFT designers, website developers, solidity developers, marketing, legal consulting, etc.) needed to complete the rest of the roadmap.
+**There is no expectation of profit with this token. It is a governance token. You are not receiving fractionalized ownership of the DAOs assets in exchange for the token, check our FAQs for more information and disclaimers.**
 
-4. The token raise will occur on [juicebox.money](https://juicebox.money/#/p/moondao), and for every contribution we will create governance tokens at a fixed rate. You will receive a portion of those tokens in your wallet, and then some will stay with the DAO in order to fund the work required to make this DAO function, and those tokens will form part of the shared treasury that you can vote on with your tokens.
-
-There is no expectation of profit with this token. It is a governance token. You are not receiving fractionalized ownership of the DAOs assets in exchange for the token, check our FAQs for more information and disclaimers.
+##

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -54,6 +54,11 @@ module.exports = {
           label: 'Contribute',
           position: 'right',
         },
+        {
+          to: 'https://snapshot.org/#/tomoondao.eth',
+          label: 'Governance',
+          position: 'right',
+        },
       ],
     },
     footer: {

--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -198,9 +198,6 @@
   "Send a MoonDAO member to space": {
     "message": "将MoonDAO成员送入太空"
   },
-  "Buy $MOONEY to join MoonDAO and send a fren to space in 2022!": {
-    "message": "购买$MOONEY来加入MoonDAO，2022年送小伙伴去外太空!"
-  },
   "Time until end of fundraise": {
     "message": "距离筹款结束的时间"
   },

--- a/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
+++ b/i18n/zh-Hans/docusaurus-theme-classic/navbar.json
@@ -4,11 +4,15 @@
     "description": "The title in the navbar"
   },
   "item.label.Documentation": {
-    "message": "Documentation",
+    "message": "文件",
     "description": "Navbar item with label Documentation"
   },
   "item.label.Contribute": {
-    "message": "Contribute",
+    "message": "贡献",
+    "description": "Navbar item with label Contribute"
+  },
+  "item.label.Governance": {
+    "message": "治理",
     "description": "Navbar item with label Contribute"
   }
 }

--- a/src/css/global.scss
+++ b/src/css/global.scss
@@ -86,7 +86,6 @@ body {
 }
 
 a {
-  color: $primary;
   text-decoration: none;
   cursor: pointer;
   transition: all 0.15s linear;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -114,7 +114,7 @@ async function fetchAndUpdateProgress() {
     ',',
   );
   const ethGoal = (TARGET_USD / usdToEth).toFixed(2);
-  document.getElementById('endRaise').textContent = '2503.78 ETH ' + String.fromCodePoint(0x23E9) + ' $' + usdReadable;
+  //document.getElementById('endRaise').textContent = '2495.15 ETH ' + String.fromCodePoint(0x23E9) + ' $' + usdReadable;
 }
 
 const BrowserOnlyAxios = () => {
@@ -142,16 +142,11 @@ export default function Home() {
               <h1 className="daoColor" id="homeTitle">
                 <Translate>Send a MoonDAO member to space</Translate>
               </h1>
-              <p className="BigP">
-                <Translate>
-                  Buy $MOONEY to join MoonDAO and send a fren to space in 2022!
-                </Translate>
-              </p>
               <h2 className="daoColor" id="endRaiseTitle">
                 <Translate>Our token launch raised...</Translate>
               </h2>
               <h1 className="BigP" id="endRaise">
-                2503.78 ETH &#x23E9; ...
+                2495.15 ETH
               </h1>
               <p className="BigP" id="thankYou">
                 <Translate>


### PR DESCRIPTION
This will close #39. However, we may want to adjust the token balance listed on the home page later as we have to make a few refunds from our gnosis safe due to late contributions.

Other changes:

- updated token page to be in past tense and remove the links to Juicbox and instruction videos.
- Added a "governance" link to top menu pointing to our Snapshot and included Chinese translations (@goofystoic: I used Google Translate for this so you might want to review it.
- Removed "Buy $MOONEY and send a fren to space" language since it's not relevant post-fundraise.
- changed style on links to make them easier to read.