### PR TITLE
autoplay fix for mobile

### DIFF
--- a/src/Components/Hero.jsx
+++ b/src/Components/Hero.jsx
@@ -17,6 +17,7 @@ const Hero = () => {
                 id="NFTVideo"
                 autoPlay
                 muted
+                playsInline
                 src="img/NFTTicketV3.mp4"
                 onMouseEnter={(e) => e.target.play()}
                 onLoadedData={(e) => e.target.play()}


### PR DESCRIPTION
NFT video wasn't autoplaying on mobile and opened up fullscreen mode. This should fix it.